### PR TITLE
configure restarter hook for aldryn-platform

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -35,6 +35,13 @@ class Form(forms.BaseForm):
         # TODO: break out a lot of this stuff into other Addons
         settings['INSTALLED_APPS'].extend([
             'cms',
+            # 'aldryn_django_cms' must be after 'cms', otherwise we get
+            # import time exceptions on other packages (e.g alryn-bootstrap3
+            # returns:
+            # link_page = cms.models.fields.PageField(
+            # AttributeError: 'module' object has no attribute 'fields'
+            # )
+            'aldryn_django_cms',
             'treebeard',
             'menus',
             'sekizai',

--- a/aldryn_django_cms/models.py
+++ b/aldryn_django_cms/models.py
@@ -2,18 +2,26 @@
 import requests
 
 from django.conf import settings
-from django.dispatch import receiver
 
 import cms.signals
 
 
-@receiver(cms.signals.urls_need_reloading, dispatch_uid='aldryn-django-cms-cloud-apphook')
+RESTARTER_URL = getattr(settings, 'RESTARTER_URL', None)
+RESTARTER_PAYLOAD = getattr(settings, 'RESTARTER_PAYLOAD', None)
+
+
 def trigger_server_restart(**kwargs):
     # internal endpoint to trigger safe restart
-    restarter_url = getattr(settings, 'RESTARTER_URL', None)
+    restarter_url = RESTARTER_URL
 
     if restarter_url:
         requests.post(
             restarter_url,
-            data={'info': getattr(settings, 'RESTARTER_PAYLOAD', None)}
+            data={'info': RESTARTER_PAYLOAD}
         )
+
+if RESTARTER_URL and RESTARTER_PAYLOAD:
+    cms.signals.urls_need_reloading.connect(
+        trigger_server_restart,
+        dispatch_uid='aldryn-django-cms-cloud-apphook',
+    )


### PR DESCRIPTION
enables a webhook if the cms is in need of a restart due to changes in
apphook configuration.

I'll make separate pull requests with cherry-picked versions for the other release channels once this is approved.
