### PR TITLE
Fix dependency failure on Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'lxml',
         'django-treebeard',
         'django-simple-captcha',
-        'BeautifulSoup',
+        'BeautifulSoup4',
         'django-parler',
         'django-robots',
         'aldryn-boilerplates',


### PR DESCRIPTION
BeautifulSoup 3.2.1

This package is OBSOLETE. It has been replaced by the beautifulsoup4 package. You should use Beautiful Soup 4 for all new projects.

Source : https://pypi.python.org/pypi/BeautifulSoup/3.2.1
