### PR TITLE
Revert "3.1.x: Pin django-filer and django-polymorphic version."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ setup(
         'django-parler',
         'django-robots',
         'aldryn-boilerplates',
-        'django_polymorphic>=0.7,<0.8',
-        'django-filer>=1.0.0,<=1.0.4',
+        'django-filer',
         # hvad >= 1.x introduced newer internal apis
         # aldryn packages have not been upgraded
         # to support these changes


### PR DESCRIPTION
Reverts aldryn/aldryn-django-cms#25 due to `django-filer` fix ( https://github.com/divio/django-filer/releases/tag/1.0.5 ) which is more appropriate.
