### PR TITLE
use more defaults for language configuration

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -118,40 +118,15 @@ class Form(forms.BaseForm):
         settings['CMS_LANGUAGES'] = {
             'default': {
                 'fallbacks': [fbcode for fbcode in language_codes],
-                'redirect_on_fallback': True,
-                'public': True,
-                'hide_untranslated': False,
             },
             1: [
                 {
                     'code': code,
                     'name': settings['ALL_LANGUAGES_DICT'][code],
                     'fallbacks': [fbcode for fbcode in language_codes if fbcode != code],
-                    'public': True
                 } for code in language_codes
             ]
         }
-
-
-        settings['PARLER_LANGUAGES'] = {}
-
-        for site_id, languages in settings['CMS_LANGUAGES'].items():
-            if isinstance(site_id, int):
-                langs = [
-                    {
-                        'code': lang['code'],
-                        'fallbacks': [fbcode for fbcode in language_codes if fbcode != lang['code']]
-                    } for lang in languages
-                ]
-                settings['PARLER_LANGUAGES'].update({site_id: langs})
-
-        parler_defaults = {'fallback': settings['LANGUAGE_CODE']}
-
-        for k, v in settings['CMS_LANGUAGES'].get('default', {}).items():
-            if k in ['hide_untranslated', ]:
-                parler_defaults.update({k: v})
-
-        settings['PARLER_LANGUAGES'].update({'default': parler_defaults})
 
         # aldryn-boilerplates and aldryn-snake
 


### PR DESCRIPTION
Previously we set hide_untranslated=False, which is not the default in django-cms and the django-cms default makes more sense.

With this change the default override is removed and all other
settings which matched the defaults anyway were removed.

django-parler adopts the settings from django-cms anyway, if
PARLER_LANGUAGES is not defined, so we let parler do it's thing as well
by removing our settings.
