### PR TITLE
Clarifies "Enable permission checks" option

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -18,7 +18,7 @@ class Form(forms.BaseForm):
         'Enable permission checks',
         required=False,
         initial=True,
-        help_text='Enables in the edit-view of pages to assign users to pages and grant them specific permissions.',
+        help_text='When set, provides new fields in each page's settings to assign levels of access to particular users.',
     )
     cms_templates = forms.CharField(
         'CMS Templates',

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -18,6 +18,7 @@ class Form(forms.BaseForm):
         'Enable permission checks',
         required=False,
         initial=True,
+        help_text='Enables in the edit-view of pages to assign users to pages and grant them specific permissions.',
     )
     cms_templates = forms.CharField(
         'CMS Templates',


### PR DESCRIPTION
Adds help text to clarify the permission option.

![image](https://cloud.githubusercontent.com/assets/270307/15108202/e7c8dcaa-15d4-11e6-8a11-a5d44a1fd619.png)
