### PR TITLE
pin ckeditor to < 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'djangocms-googlemap',
         'djangocms-link',
         'djangocms-snippet',
-        'djangocms-text-ckeditor>=2.9.3',
+        'djangocms-text-ckeditor>=2.9.3,<3.0',
 
         # Recommended plugins
         # -------------------


### PR DESCRIPTION
djangocms-text-ckeditor 3.0 won't work on 3.2

This can only be released once this is released https://github.com/aldryn/aldryn-django-cms/pull/50
