### PR TITLE
Relaxed sortedm2m version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,9 @@ setup(
         'django-compressor',
         # Django Parler 1.6.3 has a few known issues with ckeditor.
         'django-parler<=1.6.2',
-        # Django Sortedm2m 1.3 introduced a regression.
+        # Django Sortedm2m 1.3 introduced a regression, that was fixed in 1.3.2
         # See https://github.com/gregmuellegger/django-sortedm2m/issues/80
-        'django-sortedm2m<=1.2.2',
+        'django-sortedm2m>=1.2.2,!=1.3.0,!=1.3.1',
         'django-robots',
         'django-simple-captcha',
         'lxml',


### PR DESCRIPTION
The regression that required pinning was fixed in 1.3.2
