### PR TITLE
Bumped version to 3.4.6.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,10 @@ Changelog
 =========
 
 
-3.4.6.4 (unreleased)
+3.4.6.4 (2019-04-04)
 ====================
 
+* Fixed an issue with psycopg2 pinning to 2.8 for now
 * Extended test matrix
 * Added isort and adapted imports
 * Adapted code base to align with other supported addons

--- a/aldryn_django_cms/__init__.py
+++ b/aldryn_django_cms/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '3.4.6.3'
+__version__ = '3.4.6.4'

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ REQUIREMENTS = [
     'django-simple-captcha',
     'lxml',
     'YURL',
+    'psycopg2<2.8',
 ]
 
 


### PR DESCRIPTION
* Fixed an issue with psycopg2 pinning to 2.8 for now
* Extended test matrix
* Added isort and adapted imports
* Adapted code base to align with other supported addons
