### PR TITLE
Removed pin for `psycopg2`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ REQUIREMENTS = [
     'django-simple-captcha',
     'lxml',
     'YURL',
-    'psycopg2<2.8',
 ]
 
 


### PR DESCRIPTION
Required for py38/39 compatibility