### PR TITLE
Fix: remove `admin:cms_page_resolve` from the whitelist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 =========
 Changelog
 =========
+* remove `admin:cms_page_resolve` from the whitelist, as this view has been removed from the CMS.
 
 
 4.0.1.15.dev4 (2024-03-26)

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -227,9 +227,6 @@ class Form(forms.BaseForm):
             # stage sso enabled
             # add internal endpoints that do not require authentication
             settings['ALDRYN_SSO_LOGIN_WHITE_LIST'].append(reverse_lazy('cms-check-uninstall'))
-            # this is an internal django-cms url
-            # which gets called when a user logs out from toolbar
-            settings['ALDRYN_SSO_LOGIN_WHITE_LIST'].append(reverse_lazy('admin:cms_page_resolve'))
 
         # Prevent injecting random comments to counter BREACH/CRIME attacks
         # into the page tree snippets, as the javascript parsing the result


### PR DESCRIPTION
remove `admin:cms_page_resolve` from the whitelist, as this view has been removed from the CMS.